### PR TITLE
Allowing users again to enter password on stdin.

### DIFF
--- a/hib-dlagent
+++ b/hib-dlagent
@@ -62,6 +62,10 @@ handle_download() {
 
   if [ -n "$USERNAME" ]; then
     LISTING_PAGES+=("$HOME_PAGE")
+    if [ -z "$PASSWORD" ]; then
+      read -rsp 'Enter Humble account password: ' PASSWORD
+      echo
+    fi
   fi
 
   for KEY in "${KEYS[@]}"; do


### PR DESCRIPTION
Fixes this issue: https://github.com/hagabaka/hib-dlagent/issues/1
