### PR TITLE
Preserve server's modification timestamp

### DIFF
--- a/hib-dlagent
+++ b/hib-dlagent
@@ -88,7 +88,7 @@ handle_download() {
   if [ $DOWNLOAD -eq 0 ]; then
     echo "$URL"
   else
-    curl -C - --retry 3 --retry-delay 3 -o "$SAVE_FILE" "$URL"
+    curl -R -C - --retry 3 --retry-delay 3 -o "$SAVE_FILE" "$URL"
   fi
 }
 


### PR DESCRIPTION
Uses the -R option to curl so that the saved file has the same
timestamp that the server reports, creating back-dated files based on
their release date.
