### PR TITLE
Provide a Makefile to install (and uninstall)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+PREFIX = /usr
+
+.PHONY: install
+install:
+	install -D -m 755 hib-dlagent $(DESTDIR)$(PREFIX)/bin/hib-dlagent
+	install -D -m 644 README $(DESTDIR)$(PREFIX)/share/doc/hib-dlagent/README
+	install -D -m 755 discover-url.py $(DESTDIR)$(PREFIX)/share/hib-dlagent/discover-url.py
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/hib-dlagent
+	rm -f $(DESTDIR)$(PREFIX)/share/doc/hib-dlagent/README
+	rm -f $(DESTDIR)$(PREFIX)/share/hib-dlagent/discover-url.py

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-install -D -m755 hib-dlagent           "$DEST/usr/bin/hib-dlagent"
-install -D -m644 README                "$DEST/usr/share/doc/hib-dlagent/README"
-install -D -m755 discover-url.py       "$DEST/usr/share/hib-dlagent/discover-url.py"
-


### PR DESCRIPTION
This allows using simply `make` to install hib-dlagent, and also includes `make uninstall` (for removing manual installations).

Arch packages can simply use `make DESTDIR="$pkgdir/" install`, which falls in line with how a great deal of packages work already.