### PR TITLE
ask user for Authy token if needed

### DIFF
--- a/discover-url.py
+++ b/discover-url.py
@@ -9,7 +9,11 @@ username = sys.argv[3]
 password = os.environ['PASSWORD']
 
 client = humblebundle.HumbleApi()
-client.login(username, password)
+try:
+    client.login(username, password)
+except humblebundle.exceptions.HumbleTwoFactorException as e:
+    print(e, end=': ', file=sys.stderr)
+    client.login(username, password, input())
 
 order_list = client.order_list()
 for order in order_list:


### PR DESCRIPTION
Humble Bundle supports Two Factor Authentication via [Authy](https://www.authy.com/), which requires to enter a numeric one time password on login. The login function in python-humblebundle is already aware of this and throws a dedicated exception. This pull request proposes handling them by asking the user about the token, the retrying with it. This would make hib-dlagent ask for a token automatically whenever it needs one.
